### PR TITLE
Feat: add config for DeleteVehicle

### DIFF
--- a/bridge/qb-core/server.lua
+++ b/bridge/qb-core/server.lua
@@ -148,7 +148,11 @@ function DreamFramework.GetOwnedVehicleOwner(plate)
 end
 
 function DreamFramework.DeleteOwnedVehicle(plate)
-    MySQL.Sync.execute('DELETE FROM player_vehicles WHERE plate = ?', { plate })
+    if DreamCore.DeleteVehicle then
+        MySQL.Sync.execute('DELETE FROM player_vehicles WHERE plate = ?', { plate })
+    else
+        MySQL.Sync.execute('UPDATE player_vehicles SET state = 2 WHERE plate = ?', { plate })
+    end
 end
 
 local function getVehicleFromVehList(hash)
@@ -183,15 +187,19 @@ function DreamFramework.InsertOwnedVehicle(plate, owner, vehicle)
 
     -- print("[InsertOwnedVehicle] INSERTING Vehicle -> SpawnCode:", vehname, "Plate:", VehicleProps['plate'])
 
-    MySQL.Sync.execute('INSERT INTO player_vehicles (license, citizenid, vehicle, hash, mods, plate, state) VALUES (@license, @citizenid, @vehicle, @hash, @mods, @plate, @state)', {
-        ['@license'] = Player.PlayerData.license,
-        ['@citizenid'] = Player.PlayerData.citizenid,
-        ['@vehicle'] = vehname, -- Vehicle spawn code (fixed)
-        ['@hash'] = VehicleProps['model'],
-        ['@mods'] = vehicle,
-        ['@plate'] = VehicleProps['plate'],
-        ['@state'] = 0,
-    })
+    if DreamCore.DeleteVehicle then
+        MySQL.Sync.execute('INSERT INTO player_vehicles (license, citizenid, vehicle, hash, mods, plate, state) VALUES (@license, @citizenid, @vehicle, @hash, @mods, @plate, @state)', {
+            ['@license'] = Player.PlayerData.license,
+            ['@citizenid'] = Player.PlayerData.citizenid,
+            ['@vehicle'] = vehname, -- Vehicle spawn code (fixed)
+            ['@hash'] = VehicleProps['model'],
+            ['@mods'] = vehicle,
+            ['@plate'] = VehicleProps['plate'],
+            ['@state'] = 0,
+        })
+    else
+        MySQL.Sync.execute('UPDATE player_vehicles SET state = 0 WHERE plate = ?', { plate })
+    end
 
     -- print("[InsertOwnedVehicle] SUCCESS: Vehicle inserted for plate:", VehicleProps['plate'])
 end

--- a/settings/DreamCore.lua
+++ b/settings/DreamCore.lua
@@ -39,6 +39,7 @@ DreamCore.ImpoundStations = {
 
     -- Add more Impound Stations here
 }
+
 DreamCore.ImpoundForm = {
     Duration = {
         selection = 'date', -- date or time
@@ -52,6 +53,14 @@ DreamCore.ImpoundForm = {
         plate = false,
     }
 }
+
+--[[ QBCORE ONLY ]]
+
+--[[ If set to true, the vehicle will be deleted from player_vehicles until the fine is paid.]]
+--[[ If set to false, the vehicle's state will be updated to 2 (impounded). ]]
+DreamCore.DeleteVehicle = true
+
+--[[ QBCORE ONLY ]]
 
 DreamCore.Target = function()
     if GetResourceState('ox_target') == 'started' then


### PR DESCRIPTION
- This setting controls whether the vehicle will be removed from the `player_vehicles` table in QB/QBX, or if its state will simply be updated to 2 (impounded).
- By keeping the vehicle in the database, there is no risk of plate duplication.
- Change the **[DreamCore.DeleteVehicle](https://github.com/MatheusFerreiraS/dream_policeimpound/blob/79b62d19449d814be8bb3c086b398b850599049d/settings/DreamCore.lua#L61)** to define whether the vehicle should be deleted from `player_vehicles` or just marked as impounded.